### PR TITLE
Add Solution Architect Skill and commands

### DIFF
--- a/.claude/commands/build-poc.md
+++ b/.claude/commands/build-poc.md
@@ -1,0 +1,81 @@
+# Build PoC
+
+Receive a confirmed scenario, collect inputs, deploy modules in order.
+
+## Invocation
+
+```
+/build-poc "<scenario description>"
+```
+
+Examples:
+```
+/build-poc "AWS + Traefik + Ollama + Keycloak for prospect Acme"
+/build-poc "Azure AKS demo with Traefik Hub and EntraID SSO for prospect Contoso"
+/build-poc "local k3d demo with full observability stack for prospect FooBar"
+```
+
+## Step 1 — Parse scenario
+
+From the description, extract:
+- **Cloud provider**: AWS / Azure / GCP / Oracle / Nutanix / local (k3d) / RunPod
+- **Components**: AI, observability, security/SSO, tools
+- **Prospect name**: used for snapshot folder
+
+Read MODULE_CATALOG.md to confirm module selection and deploy order.
+
+## Step 2 — Declare deploy plan
+
+Show SA before touching anything:
+
+```
+Deploy plan for prospect: <name>
+Cloud: <provider>
+
+Modules (in order):
+  1. compute/<provider>/<variant>
+  2. traefik/shared
+  3. security/<module>       (if SSO requested)
+  4. observability/<module>  (if monitoring requested)
+  5. ai/<module>             (if AI requested)
+  6. tools/<module>          (if tools requested)
+  7. apps/<module>
+
+Required credentials:
+  - <list what's needed>
+
+Required inputs (no defaults):
+  - <list vars that must be provided>
+```
+
+Wait for SA confirmation before proceeding.
+
+## Step 3 — Collect inputs
+
+For each module in the plan:
+1. Read `variables.tf`
+2. Identify vars with no default
+3. Ask SA for all missing values — one round, grouped together
+4. Do NOT ask for vars that have defaults unless SA wants to override
+
+## Step 4 — Deploy
+
+For each module in plan order:
+
+```bash
+cd <module-path>
+terraform init -input=false
+terraform apply -auto-approve -var="<key>=<value>" ...
+```
+
+- Deploy compute first — capture kubeconfig output before next module
+- Pass kubeconfig to all subsequent k8s modules via `KUBECONFIG` env var
+- If any module fails: stop, report exact error, do NOT continue
+- Never run `terraform destroy` — only `apply`
+- If KUBECONFIG not set after compute deploy, stop and report
+
+## Rules
+
+- Never auto-apply without showing deploy plan first
+- Match the prospect's stated cloud preference — do not substitute without asking
+- Keep the PoC minimal: only deploy what the scenario requires

--- a/.claude/commands/extract-scenario.md
+++ b/.claude/commands/extract-scenario.md
@@ -1,0 +1,93 @@
+# Extract Scenario
+
+Read unstructured prospect input and produce a structured scenario ready for `/build-poc`.
+
+## Invocation
+
+```
+/extract-scenario <path-to-file>
+```
+
+The file can be any plain text format: `.md`, `.txt`, `.pdf` (text-based), email export, transcript export.
+
+Read the file at the given path before proceeding. If the file does not exist or is unreadable, report the error and stop.
+
+## Step 1 — Extract prospect context
+
+| Field | What to look for |
+|---|---|
+| Prospect name | Company name, domain, sender org |
+| Industry | Financial services, healthcare, retail, public sector, etc. |
+| Current infra | Cloud provider mentioned, existing Kubernetes, on-prem |
+| Pain points | What problem they're trying to solve |
+| Constraints | Compliance (GDPR, HIPAA), air-gap, no GPU, budget signals |
+| Timeline | Demo urgency — "next week", "end of quarter" |
+| Key stakeholders | DevOps, platform team, CISO, etc. |
+
+## Step 2 — Map to modules
+
+Read MODULE_CATALOG.md, then map every technical signal:
+
+| Signal in text | Module |
+|---|---|
+| "AWS", "EKS", "Amazon" | compute/aws/eks + compute/aws/vpc |
+| "Azure", "AKS", "Microsoft" | compute/azure/aks |
+| "GCP", "GKE", "Google Cloud" | compute/gcp/gke |
+| "on-prem", "no cloud", "local" | compute/suse/k3d |
+| "Nutanix", "NKP" | compute/nutanix/nkp |
+| (always) | traefik/shared — include in every PoC |
+| "AI", "LLM", "chatbot", "copilot" | ai/ollama/k8s (CPU) or ai/LLMs/runpod (GPU) |
+| "AI gateway", "MCP", "model routing" | ai/ai-gateway-dependencies/k8s |
+| "vector search", "RAG", "embeddings" | ai/milvus/k8s or ai/weaviate/k8s |
+| "SSO", "OIDC", "Azure AD", "EntraID" | security/entraid |
+| "SSO", "OIDC", "Cognito" | security/cognito |
+| "SSO", "OIDC", "Keycloak", "generic" | security/keycloak/k8s |
+| "monitoring", "observability", "Grafana" | observability/grafana-stack/k8s |
+| "tracing", "OpenTelemetry" | observability/opentelemetry/k8s + grafana-tempo/k8s |
+| "AI observability", "LLM tracing" | observability/langfuse/k8s |
+| "database", "PostgreSQL" | tools/postgresql/k8s |
+| "cache", "Redis" | tools/redis/k8s |
+| "DNS", "Cloudflare" | tools/cloudflare |
+| "load test", "k6" | tools/k6-operator/k8s |
+| "GitOps", "ArgoCD" | tools/argocd/k8s |
+| "data masking", "PII", "Presidio" | ai/presidio/k8s |
+| "demo app", "sample app" | apps/whoami/k8s or apps/httpbin/k8s |
+
+## Step 3 — Identify gaps
+
+Flag anything with NO matching module:
+- List each gap explicitly
+- Suggest closest alternative if one exists
+- Mark as "out of scope for this PoC" if nothing applies
+
+## Step 4 — Output
+
+### A. Scenario summary
+
+```
+Prospect:    <name>
+Industry:    <industry>
+Cloud:       <provider>
+Constraints: <list or "none identified">
+Timeline:    <urgency or "not mentioned">
+
+Modules selected:
+  ✅ compute/<path>        — <reason from text>
+  ✅ traefik/shared        — always included
+  ✅ security/<path>       — <reason from text>
+  ✅ <module>              — <reason from text>
+
+Gaps (not covered by available modules):
+  ⚠️  <requirement>       — <explanation>
+
+Questions before building:
+  1. <question if critical info missing>
+```
+
+## Rules
+
+- Never invent a cloud provider — if not mentioned, ask SA before defaulting
+- Always include `traefik/shared` — it's the point of every demo
+- If transcript mentions multiple clouds, pick the one with strongest signal and flag ambiguity
+- If no AI components mentioned, do not add AI modules — match what was asked
+- Keep gaps list honest — do not map requirements to modules that don't fit

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,0 +1,73 @@
+# Preflight
+
+Run before any cloud deploy to catch broken modules early. Always use `make` targets — they are the source of truth for what CI runs.
+
+## Tier 1 — Format + lint (always run, no cloud creds needed)
+
+```bash
+make preflight
+```
+
+Runs `make fmt-check` (formatting) then `make lint` (tflint) across all modules. Completes in seconds.
+
+If formatting issues found:
+- List the affected files
+- Ask SA: "Auto-fix formatting? (y/n)"
+- If yes: run `make fmt`
+- If no: report and continue to lint
+
+If lint fails:
+- Report exact tflint output (file + line + rule)
+- Do NOT auto-fix — lint errors are logic/config problems
+- Wait for SA to decide
+
+## Tier 2 — Validate (only modules about to be deployed)
+
+`terraform init` is slow per-module — only run on modules in the deploy plan.
+
+```bash
+make validate MODULE=<path>
+```
+
+If SA says "validate all":
+
+```bash
+for module in $(find . -name "versions.tf" | xargs -I{} dirname {} | sed 's|^\./||' | sort); do
+  make validate MODULE=$module
+done
+```
+
+Warn SA this will take several minutes across 57 modules before running.
+
+## Output format
+
+```
+── Tier 1: make preflight ─────────────────────────────
+✅ fmt-check passed
+✅ tflint passed
+
+── Tier 2: make validate ──────────────────────────────
+compute/azure/aks      ✅ valid
+compute/aws/eks        ✅ valid
+ai/ollama/k8s          ❌ Error: unsupported argument
+                          on main.tf line 12: An argument named "replicas"
+                          is not expected here.
+```
+
+## Rules
+
+**May fix automatically:**
+- Formatting only — `make fmt` when SA confirms. Whitespace/indentation only, never logic.
+
+**Must never fix automatically:**
+- Lint errors — report file + line + rule, let SA decide
+- Validate errors — report exact error + file:line, let SA decide
+- Missing `versions.tf` — flag it, do not create it (provider version is architecture decision)
+- Never run `terraform plan` or `terraform apply` without SA confirmation
+
+**Must always report:**
+- Any module where `make validate` exits non-zero
+- Any module missing `versions.tf`
+- Files failing `make fmt-check`
+
+**Skip:** `.terraform/` directories

--- a/.claude/commands/snapshot-poc.md
+++ b/.claude/commands/snapshot-poc.md
@@ -1,0 +1,65 @@
+# Snapshot PoC
+
+Capture what was deployed for the prospect record. Run after all modules deployed successfully.
+
+## Invocation
+
+```
+/snapshot-poc
+```
+
+Reads the current deploy context (prospect name, modules deployed, outputs).
+
+## Output location
+
+Write to `~/poc-snapshots/<prospect-name>-<YYYY-MM>/` — always outside this repo.
+
+If the directory does not exist, create it. One snapshot per prospect+month — do not overwrite existing snapshots.
+
+## Snapshot structure
+
+```
+demo-snapshots/<prospect-name>-<YYYY-MM>/
+  DEMO.md          ← human-readable summary
+  modules.tf       ← exact module sources + versions used
+  inputs.tfvars    ← all var values used (passwords/tokens redacted)
+  outputs.md       ← endpoints, URLs, credentials produced
+```
+
+## DEMO.md template
+
+```markdown
+# PoC — <Prospect Name>
+
+**Date**: <YYYY-MM-DD>
+**Cloud**: <provider>
+**Built by**: SA agent
+
+## What was deployed
+
+<one paragraph describing the scenario>
+
+## Modules used
+
+| Module | Purpose |
+|---|---|
+| compute/PROVIDER/VARIANT | cluster type |
+| traefik/shared | Traefik Hub |
+| security/MODULE | identity provider |
+
+## Access points
+
+| Service | URL | Notes |
+|---|---|---|
+| Traefik Dashboard | https://... | admin/admin |
+| Keycloak | https://... | |
+
+## Credentials
+
+See inputs.tfvars (passwords redacted in this file).
+```
+
+## Rules
+
+- Never store raw secrets — redact or omit all passwords, tokens, API keys
+- One snapshot per prospect+month — do not overwrite existing snapshots

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make fmt-check)",
+      "Bash(make fmt)",
+      "Bash(make lint)",
+      "Bash(make preflight)",
+      "Bash(make validate*)",
+      "Bash(terraform fmt*)",
+      "Bash(terraform validate)",
+      "Bash(terraform init -backend=false*)",
+      "Bash(tflint --recursive)"
+    ]
+  }
+}

--- a/.claude/skills/sa-assistant.md
+++ b/.claude/skills/sa-assistant.md
@@ -1,0 +1,38 @@
+# SA Assistant
+
+You are a Solution Architect assistant for Traefik Hub at Traefik Labs.
+
+Your role is to help SAs build technical PoCs for prospects quickly and reliably. You understand the full module catalog in MODULE_CATALOG.md (read it when you need module details, credentials, or deploy order) and orchestrate the available commands in the right order.
+
+## Persona
+
+- You know Traefik Hub deeply — API gateway, MCP gateway, API portal, OIDC, observability
+- You understand enterprise infrastructure — Kubernetes, cloud providers, AI/ML workloads
+- You are practical: pick the simplest module combination that proves the value, not the most impressive
+- You are honest about gaps: if a prospect requirement has no matching module, say so
+
+## Workflow
+
+When activated, guide the SA through this sequence — skipping steps that aren't needed:
+
+```
+1. Intake           → SA provides prospect file (email, transcript, notes)
+2. Extract scenario → /extract-scenario <path> — parse prospect input, map to modules, confirm with SA
+3. Preflight        → /preflight — validate modules before deploying
+4. Deploy           → /build-poc "<scenario>" — deploy in dependency order
+5. Snapshot         → /snapshot-poc — capture what was built
+```
+
+When SA activates this skill, ask:
+
+> "Do you have a prospect file to analyze (email, transcript, notes), or do you already have a scenario to deploy?"
+
+Then invoke the appropriate command and follow the workflow from there.
+
+## Decision rules
+
+- Never start deploying without a confirmed scenario from `/extract-scenario`
+- Never deploy without running `/preflight` first
+- If any command fails: stop, report clearly, wait for SA input — do not skip ahead
+- Match the prospect's stated cloud preference — do not substitute without asking
+- Keep the PoC minimal: only deploy what the scenario requires

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,27 @@
+name: Preflight
+
+on:
+  push:
+    paths:
+      - "**.tf"
+  pull_request:
+    paths:
+      - "**.tf"
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: preflight
+        run: make preflight

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 **/images
 
 runtime-config.yaml
+
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# terraform-demo-modules — Agent Context
+
+Reusable Terraform modules for Traefik Hub SA demos. Each module is standalone — no inter-module dependencies within this repo. Modules are composed at deploy time by the SA.
+
+## Module structure
+
+Every module follows the same pattern:
+
+```
+<category>/<provider>/<variant>/
+  main.tf        # resources
+  variables.tf   # input vars
+  outputs.tf     # outputs
+  versions.tf    # required_providers block
+```
+
+57 modules across: `ai/`, `compute/`, `observability/`, `security/`, `tools/`, `traefik/`, `apps/`.
+
+## Developer workflow
+
+### Before every commit
+
+```bash
+make preflight          # fmt-check + lint — this is the test suite for this repo
+```
+
+If it fails, fix it before pushing. CI runs the same checks.
+
+### Adding a test
+
+All checks must be Makefile targets — never run tools directly in CI or documentation. If you add a new check:
+
+1. Add a target to `Makefile`
+2. Wire it into `preflight` if it should run on every commit (fast, no cloud creds)
+3. Or add a standalone target if it's slow / needs credentials — document it in this file
+4. Update `.github/workflows/preflight.yml` if CI should run it
+
+### Auto-fix formatting
+
+```bash
+make fmt                # rewrites all .tf files in place — safe, no logic changes
+```
+
+### Deep validate a single module
+
+```bash
+make validate MODULE=compute/azure/aks   # terraform init + validate, no cloud creds
+```
+
+Run this on any module you're about to modify or deploy.
+
+### Adding a new module
+
+Every module must have exactly these four files — no more, no less:
+
+```
+<category>/<provider>/<variant>/
+  main.tf        # resources
+  variables.tf   # input vars (always define type + description + default where safe)
+  outputs.tf     # outputs (always output kubeconfig for compute modules)
+  versions.tf    # required_providers block (never modify an existing one without SA approval)
+```
+
+After creating a new module:
+1. `make fmt` — normalize formatting
+2. `make validate MODULE=<category>/<provider>/<variant>` — confirm it validates clean
+3. `make preflight` — confirm repo-wide checks still pass
+4. Update [MODULE_CATALOG.md](MODULE_CATALOG.md) — credential table + category reference
+
+### What the checks catch
+
+| Check | Command | Finds |
+|---|---|---|
+| Format | `make fmt-check` | Whitespace/indentation drift |
+| Lint | `make lint` | Invalid cloud values, deprecated args |
+| Validate | `make validate MODULE=<path>` | Syntax errors, bad references, unknown resource types |
+
+## Module catalog
+
+Full catalog in [MODULE_CATALOG.md](MODULE_CATALOG.md) — credential requirements, deploy order, full category reference.
+
+When you need module details (selecting modules for a scenario, checking credentials, deploy order), read MODULE_CATALOG.md before answering.
+
+## SA assistant
+
+Activate with `/sa-assistant`. The skill handles intake → scenario → preflight → deploy → snapshot end-to-end. See [`.claude/skills/sa-assistant.md`](.claude/skills/sa-assistant.md).

--- a/MODULE_CATALOG.md
+++ b/MODULE_CATALOG.md
@@ -1,0 +1,77 @@
+# Module Catalog
+
+57 modules across: `ai/`, `compute/`, `observability/`, `security/`, `tools/`, `traefik/`, `apps/`.
+
+## Credential requirements
+
+| Credential | Category | Modules |
+|---|---|---|
+| kubeconfig only | ai/k8s, observability, tools, apps/k8s, traefik/shared | 31 modules — no cloud creds needed |
+| AWS | compute/aws, security/cognito, traefik/ec2, traefik/ecs | EKS, EC2, ECS, VPC, Cognito |
+| Azure | compute/azure | AKS |
+| GCP | compute/gcp | GKE |
+| Oracle OCI | compute/oracle, security/oci-instance-principal | OKE |
+| Nutanix | compute/nutanix, traefik/nutanix, apps/whoami/nutanix | NKP, VMs, subnets |
+| Akamai | compute/akamai | LKE |
+| DigitalOcean | compute/digitalocean | DOKS |
+| RunPod API | ai/LLMs, ai/NIMs, ai/granite-guardian, compute/runpod | GPU cloud |
+| Cloudflare | tools/cloudflare | DNS |
+
+## Deploy order (always)
+
+```
+1. compute/        → provisions cluster, outputs kubeconfig
+2. traefik/        → deploys Traefik Hub (needs kubeconfig)
+3. security/       → identity provider (kubeconfig or cloud creds)
+4. observability/  → monitoring stack (needs kubeconfig)
+5. ai/             → AI workloads (needs kubeconfig)
+6. tools/          → utilities like postgresql, redis (needs kubeconfig)
+7. apps/           → demo workloads (needs kubeconfig)
+```
+
+## Category reference
+
+**compute/** — provisions Kubernetes clusters or VMs, always outputs kubeconfig
+- `aws/eks` — EKS cluster. Required: `cluster_name`. Outputs: kubeconfig (host, ca_cert, token)
+- `azure/aks` — AKS cluster. Required: `cluster_name`, `resource_group_name`. Outputs: kubeconfig
+- `gcp/gke` — GKE cluster. Required: `cluster_name`. Outputs: kubeconfig
+- `oracle/oke` — OKE cluster. Required: `cluster_name`. Outputs: kubeconfig
+- `digitalocean/doks` — DOKS cluster. Required: `cluster_name`. Outputs: kubeconfig
+- `akamai/lke` — LKE cluster. Required: `cluster_name`. Outputs: kubeconfig
+- `suse/k3d` — local k3d cluster. All optional. Outputs: kubeconfig
+- `nutanix/nkp` — NKP cluster. Required: `cluster_name`, `cluster_id`, `subnet_uuid`, `image_uuid` (15 required inputs)
+- `aws/vpc`, `aws/ec2`, `aws/ecs` — AWS infra primitives
+- `runpod/auth`, `runpod/pod` — GPU cloud. Required: `runpod_api_key`
+
+**traefik/** — deploys Traefik Hub
+- `k8s` (via traefik/shared) — kubeconfig only
+- `ec2`, `ecs` — AWS, mostly optional inputs
+- `nutanix` — Required: `vm_name`, `cluster_id`, `subnet_uuid`
+- `shared` — outputs helm_values YAML, no cloud deps
+
+**security/** — identity providers
+- `keycloak/k8s` — Required: `namespace`, `users`. Outputs: user credentials. kubeconfig only
+- `cognito` — AWS Cognito. No required inputs. Outputs: user_pool_id, domain
+- `entraid` — Azure AD. No required inputs. Outputs: tenant_id, app_client_id
+- `oci-instance-principal` — Required: `compartment_id`
+
+**observability/** — all kubeconfig only, all require `namespace`
+- `grafana/k8s`, `grafana-loki/k8s`, `grafana-stack/k8s`, `grafana-tempo/k8s`
+- `prometheus/k8s`, `opentelemetry/k8s`
+- `langfuse/k8s` — outputs API keys (public_key, secret_key)
+
+**ai/** — AI/ML workloads
+- k8s modules (kubeconfig only): `ollama/k8s`, `open-webui/k8s`, `milvus/k8s`, `weaviate/k8s`, `presidio/k8s`, `knative/k8s`, `23ai/k8s`, `ai-gateway-dependencies/k8s`
+- RunPod modules (GPU cloud): `LLMs/runpod`, `NIMs/runpod`, `granite-guardian/runpod` — require `runpod_api_key` + model token
+
+**tools/** — all kubeconfig only, all require `namespace`
+- `postgresql/k8s` — optional: `password`, `database`
+- `redis/k8s` — optional: `password`, `replicaCount`
+- `argocd/k8s` — optional: `admin_password`, ingress vars
+- `cert-manager/k8s`, `nginx/k8s`, `mcp-inspector/k8s`, `k6-operator/k8s`
+- `cloudflare` — Required: `zone_id`, `domain`. Cloud creds: Cloudflare API token
+
+**apps/** — sample workloads for demos
+- `httpbin/k8s`, `whoami/k8s` — no required inputs
+- `whoami/ec2`, `whoami/ecs` — AWS
+- `whoami/nutanix` — Required: `vm_name`, `cluster_id`, `subnet_uuid`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,46 @@
 VERSION := $(shell git tag --list 'v*' | sort -V | tail -n1 2>/dev/null || echo "v0.0.0")
 
-.PHONY: bump_major bump_minor bump_patch release
+.PHONY: bump_major bump_minor bump_patch release preflight fmt-check fmt validate lint
+
+##
+## Validation
+##
+
+# Fast format check across all modules — no init needed
+fmt-check:
+	@echo "==> terraform fmt check"
+	@terraform fmt -check -recursive . && echo "✅ All files formatted" || (echo "❌ Run 'make fmt' to fix" && exit 1)
+
+# Auto-fix formatting
+fmt:
+	@echo "==> terraform fmt (auto-fix)"
+	@terraform fmt -recursive .
+	@echo "✅ Done"
+
+# Deep validate a single module. Usage: make validate MODULE=compute/azure/aks
+validate:
+ifndef MODULE
+	$(error MODULE is required. Usage: make validate MODULE=compute/azure/aks)
+endif
+	@echo "==> terraform validate: $(MODULE)"
+	@cd $(MODULE) && \
+		terraform init -backend=false -input=false -upgrade=false > /dev/null && \
+		terraform validate && \
+		echo "✅ $(MODULE): valid" || \
+		(echo "❌ $(MODULE): FAILED" && exit 1)
+
+# Lint all modules with tflint (catches invalid cloud values, deprecated args)
+# Requires tflint: https://github.com/terraform-linters/tflint
+lint:
+	@echo "==> tflint"
+	@tflint --recursive && echo "✅ tflint passed" || (echo "❌ tflint found issues" && exit 1)
+
+# Tier 1 preflight: format check + lint (fast, no cloud creds needed)
+# For deep validate, run: make validate MODULE=<path>
+preflight: fmt-check lint
+	@echo ""
+	@echo "Tier 1 complete. To validate a specific module:"
+	@echo "  make validate MODULE=compute/azure/aks"
 
 # Helper to bump version
 # Usage: make bump_part PART=major|minor|patch

--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # terraform-demo-modules
-Repository containing shared resources for demos
+
+Reusable Terraform modules for provisioning Traefik Hub demo environments across multiple cloud providers and Kubernetes distributions.
+
+## Module catalog
+
+```
+ai/            AI/ML workloads (Ollama, NVIDIA NIMs, Milvus, Weaviate, Open WebUI, Presidio…)
+compute/       Kubernetes clusters (EKS, AKS, GKE, OKE, DOKS, LKE, NKP, K3d) + VMs
+observability/ Grafana stack, Prometheus, Loki, Tempo, Langfuse, OpenTelemetry
+security/      Identity providers (Keycloak, Cognito, EntraID, OCI Instance Principal)
+tools/         Utilities (ArgoCD, cert-manager, Cloudflare, k6, PostgreSQL, Redis…)
+traefik/       Traefik Hub deployment (EC2, ECS, Kubernetes, Nutanix)
+apps/          Sample workloads (whoami, httpbin)
+```
+
+## Validation
+
+Three ways to run the same checks — pick what fits your context.
+
+### CLI (local, before deploying)
+
+```bash
+make fmt-check          # check terraform formatting across all modules
+make fmt                # auto-fix formatting
+make lint               # tflint: catch invalid cloud values, deprecated args
+make preflight          # fmt-check + lint combined
+make validate MODULE=compute/azure/aks   # deep validate one module (requires terraform init)
+```
+
+`make preflight` is the recommended command before any cloud deploy. It runs without cloud credentials and completes in seconds.
+
+`make validate` runs `terraform init -backend=false` + `terraform validate` on a single module. Use it on modules you are about to deploy.
+
+### GitHub Actions (CI, on push/PR)
+
+Runs automatically on every push or PR that touches a `.tf` file:
+
+```bash
+make preflight   # fmt-check + lint
+```
+
+See [`.github/workflows/preflight.yml`](.github/workflows/preflight.yml).
+
+### Agent (Claude Code)
+
+Open this repo in Claude Code and run `/preflight` or ask "validate compute/azure/aks". The agent calls the same Makefile targets, reads the output, and explains any failures in plain language.
+
+See [`.claude/skills/preflight.md`](.claude/skills/preflight.md) for agent behavior rules.
+
+## What each check catches
+
+| Check | Tool | Needs cloud creds | What it finds |
+|---|---|---|---|
+| Format | `terraform fmt -check` | No | Whitespace/indentation drift |
+| Lint | `tflint` | No | Invalid values, deprecated args, missing tags |
+| Validate | `terraform validate` | No (init only) | Syntax errors, wrong resource types, bad references |
+| Plan | `terraform plan` | Yes | Real-world apply errors — run manually |
+
+## Contributing
+
+### Adding a module
+
+Every module must have exactly these four files:
+
+```
+<category>/<provider>/<variant>/
+  main.tf        # resources
+  variables.tf   # input vars (type + description + default where safe)
+  outputs.tf     # outputs (compute modules must output kubeconfig)
+  versions.tf    # required_providers block
+```
+
+After adding a module:
+
+```bash
+make fmt                                         # normalize formatting
+make validate MODULE=<category>/<provider>/<variant>   # confirm clean validate
+make preflight                                   # confirm repo-wide checks pass
+```
+
+Update the module catalog in CLAUDE.md (credential table + category reference + scenario mapping).
+
+### Pre-commit checklist
+
+```bash
+make preflight   # must pass — same checks CI runs
+```
+
+## Releasing
+
+```bash
+make bump_patch   # or bump_minor / bump_major
+make release      # push git tag
+```


### PR DESCRIPTION
## Summary

- **SA assistant skill** (`/sa-assistant`) — orchestrates the full PoC workflow: intake → extract scenario → preflight → deploy → snapshot
- **4 slash commands** with detailed instructions:
  - `/extract-scenario <path>` — parses prospect emails/transcripts, maps to modules, surfaces gaps
  - `/preflight` — runs `make preflight` (fmt + lint) + per-module validate before any deploy
  - `/build-poc "<scenario>"` — declare deploy plan, collect inputs, execute in dependency order
  - `/snapshot-poc` — captures deployed state to `~/poc-snapshots/` (always outside this repo)
- **MODULE_CATALOG.md** — extracted from CLAUDE.md; agent reads it on demand for module selection, credentials, and deploy order
- **CLAUDE.md** — refocused as developer context: pre-commit gate (`make preflight`), new module checklist, adding-a-test convention (Makefile as source of truth)
- **README.md** — added Contributing section with module structure and pre-commit checklist
- **CI** (`preflight.yml`) — now calls `make preflight` instead of raw terraform/tflint commands; adds tflint setup step so CI matches local exactly

## Test plan

- [ ] `/preflight` runs `make preflight` and reports fmt + lint results correctly
- [ ] `/extract-scenario <path>` parses a prospect file and produces a scenario summary with module selection
- [ ] `/build-poc` shows deploy plan and waits for SA confirmation before applying
- [ ] `/snapshot-poc` writes to `~/poc-snapshots/` and not inside the repo
- [ ] `make preflight` passes locally
- [ ] CI workflow runs `make preflight` on `.tf` file changes
