### PR TITLE
Add test fixtures for sa-assistant skill

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,28 @@
+# Fixtures — sa-assistant test inputs
+
+Synthetic prospect conversations for testing the `sa-assistant` skill and `/extract-scenario` command.
+
+Each subfolder is a self-contained input that mimics what an SA would receive from a real prospect.
+
+| Folder | Company | Cloud | Core use case |
+|---|---|---|---|
+| `example-1/` | NexoVault Financial | AWS / EKS | API management + Cognito SSO + Grafana observability |
+| `example-2/` | MedPilot Health | Azure / AKS | AI chatbot with PII masking (HIPAA) + EntraID |
+| `example-3/` | Cartify Commerce | GCP / GKE | MCP gateway for internal AI agents + Keycloak |
+| `example-4/` | Montréal 2027 Candidature Committee | N/A | **Wrong recipient** — construction RFQ for an Eiffel Tower replica, not a Traefik prospect |
+| `example-impossible/` | SocialLoop Media | GCP / GKE | **Fictional product** — "Traefik Facebook Gateway" does not exist |
+
+## Usage
+
+```
+/extract-scenario fixtures/example-1/transcript.md
+/extract-scenario fixtures/          # batch mode — produces one YAML per example
+```
+
+## What each example exercises
+
+- **example-1**: Happy path — all modules exist, no gaps, clear cloud/auth/observability signals.
+- **example-2**: Gap detection — EntraID has a Terraform module (`terraform/security/entraid`) but the SA notes flag it as a potential issue; also tests CPU-LLM + PII path.
+- **example-3**: MCP gateway path — exercises `ai-gateway-dependencies`, `mcp-inspector`, Keycloak realm import question, and the "nice-to-have" Milvus layer.
+- **example-4**: Wrong-recipient / off-topic rejection — email is a CAD $380M construction RFQ (Eiffel Tower replica, Île Notre-Dame). Intake should immediately reject: not a software prospect, no cloud/k8s context, zero Traefik relevance.
+- **example-impossible**: Hallucinated product detection — prospect cites "Traefik Facebook Gateway" (non-existent), references fictional features (webhook relay, ad-spend dashboard, token vault). Feasibility check should reject with clear "product does not exist" finding.

--- a/fixtures/example-1/transcript.md
+++ b/fixtures/example-1/transcript.md
@@ -1,0 +1,99 @@
+# Prospect Transcript — NexoVault Financial
+
+**Format:** Email thread + follow-up call notes  
+**SA:** Marcus Delacroix (marcus.delacroix@traefik.io)  
+**Prospect contact:** Priya Shankar, Principal Platform Engineer, NexoVault Financial  
+
+---
+
+## Email thread
+
+**From:** Priya Shankar <p.shankar@nexovault.io>  
+**To:** marcus.delacroix@traefik.io  
+**Date:** 2026-05-12  
+**Subject:** Evaluating API gateway for our internal platform
+
+Hi Marcus,
+
+Thanks for reaching out at KubeCon. We're actively evaluating API gateway solutions for the next quarter and Traefik Hub caught our attention.
+
+Quick background on us: NexoVault Financial is a B2B payments infrastructure company, ~800 engineers. We run everything on AWS. Our Kubernetes workloads are on EKS (us-east-1, two clusters — staging and prod) and we're fully in the AWS ecosystem including Cognito for user authentication.
+
+Our core pain points right now:
+
+1. **API management chaos** — we have 40+ internal microservices and no central gateway. Teams are exposing services ad-hoc with whatever ingress they feel like. We need a unified entry point with rate limiting, auth, and a developer portal so internal teams can discover and consume APIs without pinging us every time.
+2. **Compliance pressure** — we just completed a SOC 2 Type II audit and the auditors flagged the lack of centralized API access logging. We need audit-grade request logs with traceability per service, per user.
+3. **Developer experience** — our platform team is drowning in "can you give me access to X?" tickets. A self-serve API portal would reduce that by 80%.
+
+Constraints worth knowing:
+- We cannot use any GPU resources in the PoC environment due to our cloud spend policy this quarter.
+- Must integrate with AWS Cognito — we're not willing to introduce another IdP.
+- The security team wants observability built in — Grafana and Prometheus are our standard stack.
+
+Are you available this week for a call? We'd like to see a PoC if possible before end of May.
+
+Priya
+
+---
+
+**From:** Marcus Delacroix <marcus.delacroix@traefik.io>  
+**To:** p.shankar@nexovault.io  
+**Date:** 2026-05-13  
+**Subject:** RE: Evaluating API gateway for our internal platform
+
+Hi Priya,
+
+This maps really well to what Traefik Hub is built for. All three pain points are addressable and I can have a PoC running for you on your actual AWS/EKS stack.
+
+A few quick questions before I put together the environment:
+
+1. Are you okay with deploying into a temporary EKS cluster for the PoC, or do you want us to demonstrate against one of your existing clusters?
+2. Is there a specific set of APIs you'd like to expose in the portal — or should I use a representative set of sample services?
+3. For Grafana, are you running Grafana + Prometheus already in the cluster or should I provision a full observability stack?
+
+Let's sync Thursday at 2pm ET if that works.
+
+Marcus
+
+---
+
+**From:** Priya Shankar <p.shankar@nexovault.io>  
+**To:** marcus.delacroix@traefik.io  
+**Date:** 2026-05-13  
+**Subject:** RE: Evaluating API gateway for our internal platform
+
+Thursday works.
+
+To answer your questions:
+1. A fresh EKS cluster is fine — we don't want vendor tooling in our prod clusters before we've decided.
+2. Sample services are fine. We just need to see the portal experience and the auth flow.
+3. We don't have Grafana/Prometheus in the PoC environment yet — please provision the full stack.
+
+One more thing: our CISO will be on the call. He's going to ask about centralized audit logging for API calls. Please have that demoed — ideally with per-user traceability through Cognito JWT claims.
+
+Priya
+
+---
+
+## Call notes — 2026-05-15 (Marcus Delacroix)
+
+**Attendees:** Priya Shankar (Platform Eng), Derek Obi (CISO), two platform engineers from NexoVault
+
+**Key takeaways:**
+
+- Confirmed: fresh EKS cluster in us-east-1 is acceptable. They will not give us access to their VPC — we spin our own.
+- Cognito user pool already exists; they'll give us the pool ID and client ID before the PoC.
+- Derek specifically asked for: API-level access logs visible in Grafana, showing which Cognito user hit which endpoint and whether the call was allowed or rejected. This is non-negotiable for sign-off.
+- The airlines demo format (portal + mock APIs + auth) was shown in the deck — Priya said "that's exactly the pattern we need."
+- Timeline: decision by end of May. They have one other vendor (Kong) in the evaluation.
+- No GPU, no external LLM services, no AI requirements for this PoC — they want pure API management and observability.
+- Budget signal: they're okay with a ~$200/week AWS spend for the PoC environment.
+
+**Modules to target:**
+- EKS (fresh cluster, us-east-1)
+- Traefik Hub on Kubernetes
+- Cognito (use their existing pool)
+- Airlines helm chart (portal + mock APIs)
+- Grafana stack (metrics + logs)
+
+**Open question:** Do they need cert-manager for TLS on the demo domain? Likely yes — will check during preflight.

--- a/fixtures/example-2/transcript.md
+++ b/fixtures/example-2/transcript.md
@@ -1,0 +1,69 @@
+# Prospect Transcript — MedPilot Health
+
+**Format:** Discovery call transcript (condensed)  
+**SA:** Sonja Brandt (sonja.brandt@traefik.io)  
+**Prospect contacts:**  
+- Tobias Keller, VP Engineering, MedPilot Health  
+- Anastasia Voronova, Security & Compliance Lead  
+
+---
+
+## Discovery call transcript — 2026-05-19
+
+**Sonja:** Thanks for joining, Tobias, Anastasia. Can you walk me through what you're trying to build?
+
+**Tobias:** Sure. MedPilot is a clinical decision support platform. We're a 200-person company, Azure-native — all our workloads run on AKS. We use EntraID for everything, SSO across the board.
+
+We want to build an internal AI assistant for our clinical staff — think: a chat interface where nurses and clinicians can ask questions about patient protocols, drug interactions, that kind of thing. The LLM would be running locally inside our cluster, not calling out to OpenAI or any external API, because of HIPAA.
+
+**Sonja:** Understood. What's the current state — do you have a model running?
+
+**Tobias:** Not yet. We've been testing with Ollama locally on developer laptops. We want to run it in the cluster. We don't have GPU nodes — our Azure subscription doesn't have GPU quota right now and procurement is slow. So it would need to run on CPU, at least for the PoC. We're thinking a small model, 7B or 8B range.
+
+**Anastasia:** Can I jump in? The compliance piece is critical for us. We're HIPAA-regulated. The model will see queries that might contain patient identifiers — names, MRNs, dates. We need to make sure that if someone accidentally pastes a patient record into the chat, that PII gets detected and masked before it ever hits the model or logs.
+
+**Sonja:** That's a great signal. We have a PII detection and masking layer built around Microsoft Presidio that sits in front of the LLM. It detects and anonymizes before the request reaches the model. Let me ask — do you need the original response to be re-identified after the model responds, or just masked end-to-end?
+
+**Anastasia:** Masked end-to-end is fine for the PoC. As long as the model never sees raw PII, we're satisfied for the compliance sign-off.
+
+**Tobias:** We also want to see how requests get routed through Traefik. The AI assistant is one use case, but we'll eventually have other internal tools — an admin portal, some internal APIs. We'd want one gateway managing it all.
+
+**Sonja:** So the arc is: AKS cluster, EntraID SSO securing the chat UI, Traefik Hub as the central gateway, Ollama running a CPU model, Presidio in front for PII scrubbing, and a chat front-end for clinical staff to interact with the model.
+
+**Tobias:** Exactly. And if you can add some observability — we use Azure Monitor but we're open to Grafana in the PoC — that would help us show the security team what's going where.
+
+**Sonja:** Grafana stack with LLM request tracing via Langfuse would cover that. You'd be able to see every model call, latency, and which user triggered it through the EntraID token.
+
+**Anastasia:** What model would you use for the CPU-only PoC?
+
+**Sonja:** Ollama defaults to llama3.2 or similar 8B model — runs on CPU without issues, just slower inference. For a PoC this is fine. If you want a production-grade GPU setup later, we have a different path for that.
+
+**Tobias:** That works. What do you need from us to get started?
+
+**Sonja:** I'll need your Azure subscription ID and AKS region preference. And we'll need your EntraID tenant ID and a client ID/secret for the OIDC integration. Can your team provide those?
+
+**Tobias:** Anastasia, can we get those to Sonja by Wednesday?
+
+**Anastasia:** Yes, I'll send them over. One constraint: we cannot have any data leave our Azure region — westeurope. The PoC needs to stay fully within EU boundaries.
+
+**Sonja:** Noted. AKS in westeurope, all services in-cluster. No external API calls from the model.
+
+**Tobias:** Timeline: we have an internal steering committee review on June 10th. We need the PoC ready and demoed by June 5th.
+
+**Sonja:** That's tight but doable. Let me get started this week.
+
+---
+
+## SA follow-up notes (Sonja Brandt, 2026-05-19)
+
+- Cloud: Azure / AKS, region westeurope (hard constraint — EU data residency)
+- Auth: EntraID — tenant ID and client credentials incoming from Anastasia by 2026-05-21
+- LLM: CPU-only, Ollama k8s module, 8B model (no GPU quota available)
+- PII layer: Presidio k8s module — masks before model sees request
+- UI: Open WebUI or similar chat front-end
+- Gateway: Traefik Hub on k8s with EntraID OIDC
+- Observability: Grafana stack + Langfuse for LLM tracing
+- Compliance constraint: HIPAA, data masking is required before model, no external API calls
+- Decision timeline: demo needed by 2026-06-05, steering committee 2026-06-10
+- No GPU, no vector DB needed for this PoC (no RAG requirement mentioned)
+- Potential gap: no EntraID Terraform module in repo — may need to use Keycloak as proxy IdP or configure EntraID manually and document it

--- a/fixtures/example-3/transcript.md
+++ b/fixtures/example-3/transcript.md
@@ -1,0 +1,109 @@
+# Prospect Transcript — Cartify Commerce
+
+**Format:** Slack export + follow-up email (internal SA notes appended)  
+**SA:** Jerome Okafor (jerome.okafor@traefik.io)  
+**Prospect contacts:**  
+- Leila Nakashima, Head of Platform Engineering, Cartify Commerce  
+- Femi Adeyemi, Staff AI Engineer  
+
+---
+
+## Slack DMs — #traefik-evaluation (exported 2026-05-20)
+
+**Leila Nakashima [10:02]**  
+Hey Jerome, following up from the webinar last week. We're at Cartify — mid-size e-commerce platform, ~150M GMV/year, fully on GCP. We run on GKE. Our AI team has been building a bunch of internal agents over the past 6 months and we have a real problem: every agent is calling APIs differently, there's no governance, no rate limiting, no visibility into which agent is hitting what.
+
+**Jerome Okafor [10:15]**  
+That's a classic MCP gateway use case. Are your agents using MCP protocol, or raw REST?
+
+**Leila Nakashima [10:18]**  
+Mix of both right now. Femi can give you more detail — he built most of them. But the plan is to standardize on MCP going forward.
+
+**Femi Adeyemi [10:24]**  
+Yeah so here's our setup: we have 5 internal tools exposed as services — inventory lookup, pricing engine, customer support history, logistics tracker, and a returns processor. We want to expose all of them as MCP tools so our agents can call them. Right now each agent has hardcoded credentials to each service. It's a mess.
+
+We want a central MCP gateway that:
+1. Routes agent calls to the right backend tool
+2. Enforces which agent can call which tool (authz)
+3. Rate limits by agent identity
+4. Gives us a log of every tool call for debugging
+
+**Jerome Okafor [10:35]**  
+Traefik Hub's MCP gateway does exactly that. Are your agents running inside the cluster, or are they external callers?
+
+**Femi Adeyemi [10:38]**  
+Inside the cluster. We run them on GKE. We use Keycloak for internal auth — we have a realm set up already with agent identities as service accounts.
+
+**Leila Nakashima [10:41]**  
+We also want something the AI team can use to test and inspect MCP calls without building a custom tool every time. Like a debugger.
+
+**Jerome Okafor [10:44]**  
+There's an MCP inspector module we can deploy alongside — it's a UI for inspecting live MCP traffic. Would cover that use case.
+
+**Leila Nakashima [10:46]**  
+Perfect. Can we also have some sample backend services in the PoC? Our actual services aren't available in a sandbox.
+
+**Jerome Okafor [10:48]**  
+Yes — we can spin up httpbin and whoami as stand-ins for your backend tools. They're good enough for demonstrating routing and auth.
+
+**Femi Adeyemi [10:52]**  
+One more thing — we're starting to build RAG agents that need a vector store. Nothing for the PoC necessarily, but if you could show Milvus or something similar deployed alongside, that would help us plan the next phase.
+
+**Jerome Okafor [11:00]**  
+We can include Milvus as an optional layer. It won't be connected to the MCP gateway in the PoC but it'll show you the deployment pattern.
+
+**Leila Nakashima [11:03]**  
+Timeline: we want to see this by end of month. We have a board presentation June 3rd where we want to show "this is how we're going to govern AI in our stack."
+
+---
+
+## Follow-up email — 2026-05-20
+
+**From:** Leila Nakashima <l.nakashima@cartify.io>  
+**To:** jerome.okafor@traefik.io  
+**Subject:** PoC requirements summary — Cartify MCP Gateway
+
+Hi Jerome,
+
+Quick summary of what we discussed:
+
+**Hard requirements:**
+- GKE cluster (GCP, us-central1)
+- Traefik Hub as MCP gateway — central routing for all internal AI tool calls
+- Keycloak integration — we have our realm config ready, can export it to you
+- Per-agent authorization and rate limiting
+- MCP inspector for the AI team to debug tool calls
+- Sample backend services (httpbin / whoami are fine)
+
+**Nice to have:**
+- Milvus vector DB deployment (future RAG use case, no connection to MCP gateway needed)
+- Basic observability (we use Grafana internally, so Prometheus + Grafana would be ideal)
+
+**Constraints:**
+- GCP only — we have committed spend there
+- No external LLM required for this PoC — it's purely about gateway/routing, not model serving
+- Keycloak is our IdP — we don't want to add another SSO system
+
+**Not in scope:**
+- Any model serving (Ollama, RunPod, etc.) — AI agents call external LLM APIs directly; we just want the MCP layer
+- Any AWS or Azure services
+
+Looking forward to seeing this built. Let me know if you need the GCP project ID or service account.
+
+Leila
+
+---
+
+## SA notes (Jerome Okafor, 2026-05-20)
+
+- Cloud: GCP / GKE, us-central1
+- Auth: Keycloak (existing realm, they'll export config) — use helm/keycloak chart or terraform/security/keycloak/k8s
+- Gateway: Traefik Hub k8s with MCP gateway mode + ai-gateway-dependencies CRDs
+- Inspector: terraform/tools/mcp-inspector/k8s — explicitly requested
+- Backend stubs: terraform/apps/httpbin/k8s + terraform/apps/whoami/k8s
+- Vector DB: terraform/ai/milvus/k8s — nice to have, no integration needed, just show the module
+- Observability: terraform/observability/grafana-stack/k8s — nice to have, include if time allows
+- No AI/LLM serving — agents call external APIs, we just manage the MCP layer
+- No GPU, no RunPod, no Ollama
+- Decision timeline: demo by 2026-05-30, board presentation 2026-06-03
+- Potential gap: Keycloak realm import — they have an existing realm config; check if our helm/keycloak chart supports importing a pre-existing realm export

--- a/fixtures/example-4/mail.eml
+++ b/fixtures/example-4/mail.eml
@@ -1,0 +1,41 @@
+Dear Thomas,
+
+My name is Frédéric Lauzon, and I am writing on behalf of the Montréal
+2027 Candidature Committee, a public-private initiative working in
+partnership with the City of Montréal and Investissement Québec.
+
+As part of our bid to host the 2027 World Exposition, we are
+exploring a flagship architectural centrepiece that would serve as
+the event's iconic landmark — specifically, a full-scale structural
+replica of the Eiffel Tower to be erected on Île Notre-Dame, adjacent
+to the existing Circuit Gilles Villeneuve grounds.
+
+We have reviewed your firm's portfolio and believe your team's
+expertise in large-scale structural engineering and project management
+makes you an ideal candidate to lead the design and construction effort. The projected timeline is 18 months from contract signing, with a target completion date of June 2027.
+
+Key deliverables we are seeking include:
+- Structural feasibility assessment for the Montréal climate (seismic zone,
+wind load, frost depth)
+
+- Full engineering plans compliant with the National Building Code of Canada
+- Coordination with the Ville de Montréal for permitting and heritage impact review
+- Construction management from foundation to final inspection
+
+The estimated project budget is CAD $380 million, funded jointly through
+federal infrastructure grants and private sponsorship.
+
+We would welcome an initial call at your earliest convenience to discuss
+scope, timeline, and next steps. Please reply to this email or reach me
+directly at +1 514-882-3401.
+
+We look forward to the possibility of working with you on what would
+undoubtedly be a historic project for Québec.
+
+Cordialement,
+
+Frédéric Lauzon
+Directeur, Partenariats Stratégiques
+Comité de Candidature Montréal 2027
+frédéric.lauzon@montreal2027.ca
++1 514-882-3401

--- a/fixtures/example-impossible/transcript.md
+++ b/fixtures/example-impossible/transcript.md
@@ -1,0 +1,71 @@
+# Prospect Transcript — SocialLoop Media
+
+**Format:** Email thread  
+**SA:** Jordan Pierce (jordan.pierce@traefik.io)  
+**Prospect contact:** Kevin Zhao, Head of Platform Engineering, SocialLoop Media  
+
+---
+
+## Email thread
+
+**From:** Kevin Zhao <k.zhao@socialloop.media>  
+**To:** jordan.pierce@traefik.io  
+**Date:** 2026-05-20  
+**Subject:** PoC request — Traefik Facebook Gateway integration
+
+Hi Jordan,
+
+We met briefly at PlatformCon and you mentioned Traefik has deep integrations with the Meta ecosystem. I wanted to follow up.
+
+SocialLoop Media runs a social content aggregation platform — ~200 engineers, GKE on GCP (us-central1). We're primarily a Meta-first shop: our backend services talk to Facebook Graph API extensively, and all our user auth flows through Facebook Login.
+
+We've been reading about **Traefik Facebook Gateway** and it looks like exactly what we need. Specifically we want to:
+
+1. **Facebook Graph API traffic management** — route and rate-limit our backend calls to the Graph API through Traefik, with automatic token refresh and per-service quota enforcement.
+2. **Facebook Login SSO** — integrate the Traefik Facebook Gateway's built-in Facebook Login provider so our internal dev portal authenticates via Facebook OAuth natively, no separate IdP.
+3. **Webhook fanout** — Traefik Facebook Gateway's webhook relay feature to distribute Facebook webhook events (page updates, ad events) to our internal microservices automatically.
+4. **Meta Business Suite metrics** — pull usage metrics from the Facebook Gateway into our existing Grafana stack.
+
+We saw the Traefik Facebook Gateway docs mention a GKE Helm chart — can you confirm which chart version supports the Meta Webhooks fanout feature? Our security team also wants to know if the Facebook Gateway's token vault is FIPS-140 compliant.
+
+Can you put together a PoC on GKE showing Graph API rate limiting + Facebook Login + webhook relay? Timeline is flexible — end of June works.
+
+Kevin
+
+---
+
+**From:** Jordan Pierce <jordan.pierce@traefik.io>  
+**To:** k.zhao@socialloop.media  
+**Date:** 2026-05-21  
+**Subject:** RE: PoC request — Traefik Facebook Gateway integration
+
+Hi Kevin,
+
+Thanks for reaching out. Let me loop in our product team to clarify the Facebook Gateway feature set before we scope the PoC.
+
+A few questions in the meantime:
+
+1. Which version of the Traefik Facebook Gateway docs were you reading? Want to make sure we're looking at the same feature set.
+2. Is Facebook Login the only IdP in scope, or do you have a fallback (Google Workspace, internal LDAP)?
+3. For the GKE cluster — fresh cluster for the PoC or one of your existing ones?
+
+Jordan
+
+---
+
+**From:** Kevin Zhao <k.zhao@socialloop.media>  
+**To:** jordan.pierce@traefik.io  
+**Date:** 2026-05-21  
+**Subject:** RE: PoC request — Traefik Facebook Gateway integration
+
+Jordan,
+
+We found the docs via a Google search — landed on what looked like official Traefik documentation. I'll try to dig up the URL.
+
+Facebook Login is the primary IdP — we're willing to add a fallback if needed but it's not priority.
+
+Fresh GKE cluster is fine for the PoC. Budget-wise we're comfortable with ~$150/week cloud spend.
+
+One more thing: the VP of Engineering specifically wants to see the **Facebook Gateway's native ad-spend analytics dashboard** demoed. Apparently that feature was announced at a Traefik meetup earlier this year. Can you confirm it's GA?
+
+Kevin

--- a/fixtures/prompt.txt
+++ b/fixtures/prompt.txt
@@ -1,0 +1,29 @@
+----------------------
+/sa-assistant  Hello, I want to build a PoC for a prospect.
+Transcripts and other are in  ./fixtures/example-1/.
+I want to use ./PROSPECT_X as my workdir.
+Please create the PoC, however, just render files.
+Do not deploy it. Skip step 7, no snapshot needed for this PoC.
+Proceed each step automatically if there are no error.
+
+----------------------
+/sa-assistant  Hello, I want to build a PoC for a prospect.
+Transcripts and other are in  ./fixtures/example-2/.
+I want to use./PROSPECT_Y as my workdir.
+
+Please create the PoC, however, just render files. Do not deploy it. 
+Skip step 7, no snapshot is needed for this PoC since it is a demo.
+Proceed each step automatically if there are no error.
+
+Use default value and placeholder if needed, but give all env
+vars that needs to be set for the deployment.
+
+----------------------
+/sa-assistant  Hello, I want to build a PoC for a prospect.
+His mail is at fixtures/example-4/mail.eml. Create the PoC, however,
+just render files in ./PROSPECT_Z.
+----------------------
+
+/sa-assistant  Hello, I want to build a PoC for a prospect.
+His mail is at fixtures/example-impossible/transcript.md.
+Create the PoC, however, just render files in ./PROSPECT_I.


### PR DESCRIPTION
## Summary

- Adds `fixtures/` directory with 5 synthetic prospect transcripts for testing the `sa-assistant` skill
- **example-1**: Happy path — NexoVault Financial, AWS/EKS, API management + Cognito + Grafana
- **example-2/3**: Gap detection and MCP gateway paths (pre-existing content, now tracked)
- **example-4**: Wrong-recipient rejection — construction RFQ for an Eiffel Tower replica in Montréal, zero Traefik relevance; intake should reject immediately
- **example-impossible**: Hallucinated product detection — prospect asks for "Traefik Facebook Gateway" (non-existent); feasibility check should block with "product does not exist"

## Test plan

- [ ] `/intake fixtures/example-4/mail.eml` — expect rejection at intake (not a software prospect)
- [ ] `/extract-scenario fixtures/example-impossible/transcript.md` → `/feasibility-check` — expect block on unknown product
- [ ] `/extract-scenario fixtures/example-1/transcript.md` — expect clean happy-path YAML